### PR TITLE
Create disemvowel-trolls.rb

### DIFF
--- a/disemvowel-trolls.rb
+++ b/disemvowel-trolls.rb
@@ -1,0 +1,4 @@
+def disemvowel(str)
+  vowels = %w[a e i o u]
+  (str.split('').select { |x| x unless vowels.include?(x.downcase || x.upcase) }).join
+end


### PR DESCRIPTION
Codewars kata

Trolls are attacking your comment section!
A common way to deal with this situation is to remove all of the vowels from the trolls' comments, neutralizing the threat.
Your task is to write a function that takes a string and return a new string with all vowels removed.
For example, the string "This website is for losers LOL!" would become "Ths wbst s fr lsrs LL!".